### PR TITLE
Add ability to pass in custom Java Options

### DIFF
--- a/ose3/s2i-java-imagestream.json
+++ b/ose3/s2i-java-imagestream.json
@@ -5,7 +5,7 @@
       "name": "s2i-java"
    },
    "spec": {
-      "dockerImageRepository": "jorgemoralespou/s2i-java",
+      "dockerImageRepository": "sufyaankazi/s2i-java"
       "tags": [
          {
             "name": "latest",

--- a/ose3/s2i-java-imagestream.json
+++ b/ose3/s2i-java-imagestream.json
@@ -5,7 +5,7 @@
       "name": "s2i-java"
    },
    "spec": {
-      "dockerImageRepository": "sufyaankazi/s2i-java",
+      "dockerImageRepository": "jorgemoralespou/s2i-java",
       "tags": [
          {
             "name": "latest",

--- a/ose3/s2i-java-imagestream.json
+++ b/ose3/s2i-java-imagestream.json
@@ -5,7 +5,7 @@
       "name": "s2i-java"
    },
    "spec": {
-      "dockerImageRepository": "jorgemoralespou/s2i-java",
+      "dockerImageRepository": "sufyaankazi/s2i-java",
       "tags": [
          {
             "name": "latest",

--- a/ose3/s2i-java-imagestream.json
+++ b/ose3/s2i-java-imagestream.json
@@ -5,7 +5,7 @@
       "name": "s2i-java"
    },
    "spec": {
-      "dockerImageRepository": "sufyaankazi/s2i-java"
+      "dockerImageRepository": "sufyaankazi/s2i-java",
       "tags": [
          {
             "name": "latest",

--- a/sti/bin/run
+++ b/sti/bin/run
@@ -10,5 +10,6 @@
 cd /opt/openshift && \
 exec java \
     -Djava.security.egd=file:/dev/./urandom \
+    $JVM_OPTIONS \
     -jar /opt/openshift/app.jar \
     $APP_OPTIONS

--- a/sti/bin/run
+++ b/sti/bin/run
@@ -7,6 +7,7 @@
 #	https://github.com/openshift/source-to-image/blob/master/docs/builder_image.md
 #
 
+echo "About to execute java -Djava.security.egd=file:/dev/./urandom $JVM_OPTIONS -jar /opt/openshift/app.jar $APP_OPTIONS"
 cd /opt/openshift && \
 exec java \
     -Djava.security.egd=file:/dev/./urandom \


### PR DESCRIPTION
Added ability to pass in custom Java options, e.g. for activating different Spring Boot Profiles. This allows an app e.g. to run in detached mode on a laptop standalone not on Openshift or Minishift - yet alternatively run on Openshift too for example to read env vars for accessing db credentials.

example project: https://github.com/Sufyaan-Kazi/spring-boot-cities-service/tree/openshift